### PR TITLE
Fustily Version Update and PCMU Header Write on Finish

### DIFF
--- a/app/audiohook/src/audio/wav.ts
+++ b/app/audiohook/src/audio/wav.ts
@@ -38,7 +38,7 @@ export class WavFileWriter {
         this.channels = channels | 0;
         if (this.format === 'PCMU') {
             this.bytesPerSample = this.channels;
-            this.header = Buffer.alloc(44);
+            this.header = Buffer.alloc(50);
             this.header.write('RIFF', 0);
             this.header.writeUInt32LE(0xffffffff, 4);
             this.header.write('WAVEfmt ', 8);
@@ -100,8 +100,8 @@ export class WavFileWriter {
             const fileEndPos = dataWriter.bytesWritten + writer.header.length;
             writer.header.writeUInt32LE(fileEndPos + pad - 8, 4);
             if (writer.format === 'PCMU') {
-                writer.header.writeUInt32LE(numSamples, 46);                // fact chunk value (number of samples)
-                writer.header.writeUInt32LE(dataWriter.bytesWritten, 54);   // data chunk size
+                writer.header.writeUInt32LE(numSamples*2, 40);              // fact chunk value (number of samples)
+                writer.header.writeUInt32LE(dataWriter.bytesWritten, 44);   // data chunk size
             } else {
                 writer.header.writeUInt32LE(dataWriter.bytesWritten, 40);   // data chunk size
             }

--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/client-secrets-manager": "^3.159.0",
     "@fastify/websocket": "^6.0.1",
     "dotenv": "^16.0.1",
-    "fastify": "^4.5.3",
+    "fastify": "~4.5.3",
     "fastify-plugin": "^3.0.1",
     "install": "^0.13.0",
     "pino": "^8.11.0",


### PR DESCRIPTION
Pinned fastify to version ~4.5.3 b/c of https://github.com/fastify/fastify/issues/4873, and modified wav file header; buffer allocation wasn't sufficient and offset for the data chunk size and data were incorrect when compared to the spec (aside: I'm not expert on WAV, but prior to this change it would throw a range error and crash the server)