### PR TITLE
Update fastify version + data chunk size correction

### DIFF
--- a/app/audiohook/src/audio/wav.ts
+++ b/app/audiohook/src/audio/wav.ts
@@ -99,12 +99,7 @@ export class WavFileWriter {
             const numSamples = dataWriter.bytesWritten / writer.bytesPerSample;
             const fileEndPos = dataWriter.bytesWritten + writer.header.length;
             writer.header.writeUInt32LE(fileEndPos + pad - 8, 4);
-            if (writer.format === 'PCMU') {
-                writer.header.writeUInt32LE(numSamples, 46);                // fact chunk value (number of samples)
-                writer.header.writeUInt32LE(dataWriter.bytesWritten, 54);   // data chunk size
-            } else {
-                writer.header.writeUInt32LE(dataWriter.bytesWritten, 40);   // data chunk size
-            }
+            writer.header.writeUInt32LE(dataWriter.bytesWritten, 40);   // data chunk size
 
             // Patch the header with the actual sizes and close the file
             (async () => {

--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/client-secrets-manager": "^3.159.0",
     "@fastify/websocket": "^6.0.1",
     "dotenv": "^16.0.1",
-    "fastify": "^4.5.3",
+    "fastify": "~4.5.3",
     "fastify-plugin": "^3.0.1",
     "install": "^0.13.0",
     "pino": "^8.11.0",


### PR DESCRIPTION
Pinned fastify to version to `~4.5.3` (see https://github.com/fastify/fastify/issues/4873). Thanks @blake-roux
Correct writing of data chunk size.